### PR TITLE
A couple last-minute suggestions

### DIFF
--- a/content/data_umbrella_dec_2_2020/data_umbrella.ipynb
+++ b/content/data_umbrella_dec_2_2020/data_umbrella.ipynb
@@ -289,7 +289,7 @@
     "- code and documentation - https://github.com/numpy/numpy \n",
     "- website - https://github.com/numpy/numpy.org\n",
     "  - https://numpy.org\n",
-    "- NEW! tutorials written in MyST-NB markdown - https://github.com/numpy/numpy-tutorials - \n",
+    "- NEW! tutorials written in Jupyter notebooks - https://github.com/numpy/numpy-tutorials - \n",
     "- formatting docstrings - https://github.com/numpy/numpydoc - \n"
    ]
   },

--- a/content/data_umbrella_dec_2_2020/data_umbrella.ipynb
+++ b/content/data_umbrella_dec_2_2020/data_umbrella.ipynb
@@ -46,7 +46,7 @@
     "\n",
     "Matti Picus, \n",
     "- Quansight developer. Previously employed by Berkeley Institute of Data Science to work full time on NumPy. \n",
-    "- Avid Open Source evangelist: have converted many Matlab users to Python and told a few that Matlab will suite their workflow better. - PyPy core contributor, and drive-by contributor to many other projects.\n",
+    "- Avid Open Source evangelist: have converted many Matlab users to Python and told a few that Matlab will suit their workflow better. - PyPy core contributor, and drive-by contributor to many other projects.\n",
     "- \"Kibbutznik\".\n",
     "- Believe that diversity and inclusion are important to human society, tech, and open source."
    ]


### PR DESCRIPTION
A couple thoughts from another careful look at the slides:
 * A typo: suite -> suit
 * Change MyST-NB reference to Jupyter notebooks, since the audience will undoubtedly be more familiar with the latter.

If people end up submitting tutorials to `numpy-tutorials` in `.ipynb` format that's totally fine, we do the conversion to the text-based format for them during the review.